### PR TITLE
feat: add peek methods to the Try monad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `fold` method to the `Try` interface for transforming a Try into a value of a different type
 - Implementation of `fold` in both `Success` and `Failure` classes
-- Documentation and usage examples for the new method
+- New `peek` methods (`peekSuccess`, `peekFailure`, and `peek`) to the `Try` interface for executing side effects without altering the Try
+- Implementation of peek methods in both `Success` and `Failure` classes
+- Documentation and usage examples for the new methods
 
 ## [1.1.0] - 2025-05-23
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,37 @@ Try<Integer> combined = Try.of(() -> "42")
     .recover(ex -> -1);
 ```
 
+### Executing Side Effects with peek
+
+```java
+// Execute a side effect only on Success
+Try<Integer> success = Try.success(42)
+    .peekSuccess(value -> System.out.println("Processing value: " + value));
+// Output: "Processing value: 42"
+
+// Execute a side effect only on Failure
+Try<Integer> failure = Try.failure(new RuntimeException("Error"))
+    .peekFailure(ex -> System.out.println("Error occurred: " + ex.getMessage()));
+// Output: "Error occurred: Error"
+
+// Use peek for both Success and Failure cases
+Try<Integer> result = Try.of(() -> Integer.parseInt("42"))
+    .peek(
+        value -> System.out.println("Success: " + value),
+        ex -> System.out.println("Failure: " + ex.getMessage())
+    );
+// Output: "Success: 42"
+
+// Chain of operations
+Try<Integer> debugged = Try.of(() -> "42")
+    .peekSuccess(s -> System.out.println("Original string: " + s))
+    .map(Integer::parseInt)
+    .peekSuccess(n -> System.out.println("Parsed integer: " + n));
+// Output:
+// "Original string: 42"
+// "Parsed integer: 42"
+```
+
 ### Integration with Optional
 
 ```java

--- a/src/main/java/io/github/borrelunde/scipio/core/Failure.java
+++ b/src/main/java/io/github/borrelunde/scipio/core/Failure.java
@@ -2,6 +2,7 @@ package io.github.borrelunde.scipio.core;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -85,6 +86,32 @@ public final class Failure<ValueType> implements Try<ValueType> {
 		} catch (Exception e) {
 			return Try.failure(e);
 		}
+	}
+
+	@Override
+	public Try<ValueType> peekSuccess(final Consumer<? super ValueType> consumer) {
+		// Do nothing for Failure
+		return this;
+	}
+
+	@Override
+	public Try<ValueType> peekFailure(final Consumer<? super Exception> consumer) {
+		Objects.requireNonNull(consumer, "Consumer cannot be null");
+		try {
+			consumer.accept(exception);
+			return this;
+		} catch (Exception e) {
+			return Try.failure(e);
+		}
+	}
+
+	@Override
+	public Try<ValueType> peek(
+			final Consumer<? super ValueType> successConsumer,
+			final Consumer<? super Exception> failureConsumer) {
+		Objects.requireNonNull(successConsumer, "Success consumer cannot be null");
+		Objects.requireNonNull(failureConsumer, "Failure consumer cannot be null");
+		return peekFailure(failureConsumer);
 	}
 
 	@Override

--- a/src/main/java/io/github/borrelunde/scipio/core/Success.java
+++ b/src/main/java/io/github/borrelunde/scipio/core/Success.java
@@ -2,6 +2,7 @@ package io.github.borrelunde.scipio.core;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -84,6 +85,32 @@ public final class Success<ValueType> implements Try<ValueType> {
 		} catch (Exception e) {
 			return Try.failure(e);
 		}
+	}
+
+	@Override
+	public Try<ValueType> peekSuccess(final Consumer<? super ValueType> consumer) {
+		Objects.requireNonNull(consumer, "Consumer cannot be null");
+		try {
+			consumer.accept(value);
+			return this;
+		} catch (Exception e) {
+			return Try.failure(e);
+		}
+	}
+
+	@Override
+	public Try<ValueType> peekFailure(final Consumer<? super Exception> consumer) {
+		// Do nothing for Success
+		return this;
+	}
+
+	@Override
+	public Try<ValueType> peek(
+			final Consumer<? super ValueType> successConsumer,
+			final Consumer<? super Exception> failureConsumer) {
+		Objects.requireNonNull(successConsumer, "Success consumer cannot be null");
+		Objects.requireNonNull(failureConsumer, "Failure consumer cannot be null");
+		return peekSuccess(successConsumer);
 	}
 
 	@Override

--- a/src/main/java/io/github/borrelunde/scipio/core/Try.java
+++ b/src/main/java/io/github/borrelunde/scipio/core/Try.java
@@ -2,6 +2,7 @@ package io.github.borrelunde.scipio.core;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -104,6 +105,36 @@ public interface Try<ValueType> {
 	<ResultType> ResultType fold(
 			final Function<? super ValueType, ? extends ResultType> successFunction,
 			final Function<? super Exception, ? extends ResultType> failureFunction);
+
+	/**
+	 * Executes the given consumer if this is a Success, otherwise does nothing.
+	 * This is useful for performing side effects on the value without altering the Try.
+	 *
+	 * @param consumer the consumer to apply to the value
+	 * @return this Try instance
+	 */
+	Try<ValueType> peekSuccess(final Consumer<? super ValueType> consumer);
+
+	/**
+	 * Executes the given consumer if this is a Failure, otherwise does nothing.
+	 * This is useful for performing side effects on the exception without altering the Try.
+	 *
+	 * @param consumer the consumer to apply to the exception
+	 * @return this Try instance
+	 */
+	Try<ValueType> peekFailure(final Consumer<? super Exception> consumer);
+
+	/**
+	 * Executes the appropriate consumer based on whether this is a Success or Failure.
+	 * This is useful for performing side effects without altering the Try.
+	 *
+	 * @param successConsumer the consumer to apply if this is a Success
+	 * @param failureConsumer the consumer to apply if this is a Failure
+	 * @return this Try instance
+	 */
+	Try<ValueType> peek(
+			final Consumer<? super ValueType> successConsumer,
+			final Consumer<? super Exception> failureConsumer);
 
 	/**
 	 * Creates a new Try by applying the given supplier.

--- a/src/test/java/io/github/borrelunde/scipio/core/PeekTest.java
+++ b/src/test/java/io/github/borrelunde/scipio/core/PeekTest.java
@@ -1,0 +1,459 @@
+package io.github.borrelunde.scipio.core;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the peek methods of the {@link Try} interface.
+ * <p>
+ * This test class is organized into logical groups based on the different peek methods:
+ * 1. WhenUsingPeekSuccessWithSuccess - Tests for peekSuccess with Success instances
+ * 2. WhenUsingPeekSuccessWithFailure - Tests for peekSuccess with Failure instances
+ * 3. WhenUsingPeekFailureWithSuccess - Tests for peekFailure with Success instances
+ * 4. WhenUsingPeekFailureWithFailure - Tests for peekFailure with Failure instances
+ * 5. WhenUsingPeekWithSuccess - Tests for peek with Success instances
+ * 6. WhenUsingPeekWithFailure - Tests for peek with Failure instances
+ * 7. WhenHandlingEdgeCases - Tests for edge cases and integration with other methods
+ * <p>
+ * Each method is tested with both Success and Failure inputs and with various scenarios
+ * including normal execution and exception handling.
+ *
+ * @author Børre A. Opedal Lunde
+ * @since 1.1.0
+ */
+@DisplayName("Peek Methods Tests")
+class PeekTest {
+
+    @Nested
+    @DisplayName("When using peekSuccess with Success")
+    class WhenUsingPeekSuccessWithSuccess {
+
+        private final String value = "test";
+        private final Try<String> success = Try.success(value);
+
+        @Test
+        @DisplayName("Should execute the consumer")
+        void shouldExecuteTheConsumer() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            success.peekSuccess(v -> consumerExecuted.set(true));
+
+            // Assert
+            assertTrue(consumerExecuted.get(), "Consumer should be executed");
+        }
+
+        @Test
+        @DisplayName("Should return original Success when consumer completes normally")
+        void shouldReturnOriginalSuccessWhenConsumerCompletesNormally() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = success.peekSuccess(v -> consumerExecuted.set(true));
+
+            // Assert
+            assertTrue(consumerExecuted.get(), "Consumer should be executed");
+            assertSame(success, result, "Should return the original Success instance");
+        }
+
+        @Test
+        @DisplayName("Should return Failure when consumer throws exception")
+        void shouldReturnFailureWhenConsumerThrowsException() {
+            // Arrange
+            RuntimeException exception = new RuntimeException("Consumer exception");
+
+            // Act
+            Try<String> result = success.peekSuccess(v -> {
+                throw exception;
+            });
+
+            // Assert
+            assertTrue(result.isFailure(), "Result should be a Failure");
+            try {
+                result.get();
+                fail("Should throw exception");
+            } catch (Exception e) {
+                assertSame(exception, e, "Exception should be the one thrown by consumer");
+            }
+            assertSame(exception, ((Failure<String>) result).getException(), "Failure should contain the thrown exception");
+        }
+    }
+
+    @Nested
+    @DisplayName("When using peekSuccess with Failure")
+    class WhenUsingPeekSuccessWithFailure {
+
+        private final Exception exception = new RuntimeException("Test exception");
+        private final Try<String> failure = Try.failure(exception);
+
+        @Test
+        @DisplayName("Should not execute the consumer")
+        void shouldNotExecuteTheConsumer() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            failure.peekSuccess(v -> consumerExecuted.set(true));
+
+            // Assert
+            assertFalse(consumerExecuted.get(), "Consumer should not be executed");
+        }
+
+        @Test
+        @DisplayName("Should return the original Failure")
+        void shouldReturnTheOriginalFailure() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = failure.peekSuccess(v -> consumerExecuted.set(true));
+
+            // Assert
+            assertFalse(consumerExecuted.get(), "Consumer should not be executed");
+            assertSame(failure, result, "Should return the original Failure instance");
+        }
+    }
+
+    @Nested
+    @DisplayName("When using peekFailure with Success")
+    class WhenUsingPeekFailureWithSuccess {
+
+        private final String value = "test";
+        private final Try<String> success = Try.success(value);
+
+        @Test
+        @DisplayName("Should not execute the consumer")
+        void shouldNotExecuteTheConsumer() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            success.peekFailure(e -> consumerExecuted.set(true));
+
+            // Assert
+            assertFalse(consumerExecuted.get(), "Consumer should not be executed");
+        }
+
+        @Test
+        @DisplayName("Should return the original Success")
+        void shouldReturnTheOriginalSuccess() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = success.peekFailure(e -> consumerExecuted.set(true));
+
+            // Assert
+            assertFalse(consumerExecuted.get(), "Consumer should not be executed");
+            assertSame(success, result, "Should return the original Success instance");
+        }
+    }
+
+    @Nested
+    @DisplayName("When using peekFailure with Failure")
+    class WhenUsingPeekFailureWithFailure {
+
+        private final Exception exception = new RuntimeException("Test exception");
+        private final Try<String> failure = Try.failure(exception);
+
+        @Test
+        @DisplayName("Should execute the consumer")
+        void shouldExecuteTheConsumer() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            failure.peekFailure(e -> consumerExecuted.set(true));
+
+            // Assert
+            assertTrue(consumerExecuted.get(), "Consumer should be executed");
+        }
+
+        @Test
+        @DisplayName("Should return original Failure when consumer completes normally")
+        void shouldReturnOriginalFailureWhenConsumerCompletesNormally() {
+            // Arrange
+            AtomicBoolean consumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = failure.peekFailure(e -> consumerExecuted.set(true));
+
+            // Assert
+            assertTrue(consumerExecuted.get(), "Consumer should be executed");
+            assertSame(failure, result, "Should return the original Failure instance");
+        }
+
+        @Test
+        @DisplayName("Should return new Failure when consumer throws exception")
+        void shouldReturnNewFailureWhenConsumerThrowsException() {
+            // Arrange
+            RuntimeException consumerException = new RuntimeException("Consumer exception");
+
+            // Act
+            Try<String> result = failure.peekFailure(e -> {
+                throw consumerException;
+            });
+
+            // Assert
+            assertTrue(result.isFailure(), "Result should be a Failure");
+            assertSame(consumerException, ((Failure<String>) result).getException(), "Failure should contain the thrown exception");
+        }
+    }
+
+    @Nested
+    @DisplayName("When using peek with Success")
+    class WhenUsingPeekWithSuccess {
+
+        private final String value = "test";
+        private final Try<String> success = Try.success(value);
+
+        @Test
+        @DisplayName("Should execute only the success consumer")
+        void shouldExecuteOnlyTheSuccessConsumer() {
+            // Arrange
+            AtomicBoolean successConsumerExecuted = new AtomicBoolean(false);
+            AtomicBoolean failureConsumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            success.peek(
+                    v -> successConsumerExecuted.set(true),
+                    e -> failureConsumerExecuted.set(true)
+            );
+
+            // Assert
+            assertTrue(successConsumerExecuted.get(), "Success consumer should be executed");
+            assertFalse(failureConsumerExecuted.get(), "Failure consumer should not be executed");
+        }
+
+        @Test
+        @DisplayName("Should return original Success when consumer completes normally")
+        void shouldReturnOriginalSuccessWhenConsumerCompletesNormally() {
+            // Arrange
+            AtomicBoolean successConsumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = success.peek(
+                    v -> successConsumerExecuted.set(true),
+                    e -> fail("Failure consumer should not be executed")
+            );
+
+            // Assert
+            assertTrue(successConsumerExecuted.get(), "Success consumer should be executed");
+            assertSame(success, result, "Should return the original Success instance");
+        }
+
+        @Test
+        @DisplayName("Should return Failure when success consumer throws exception")
+        void shouldReturnFailureWhenSuccessConsumerThrowsException() {
+            // Arrange
+            RuntimeException exception = new RuntimeException("Consumer exception");
+
+            // Act
+            Try<String> result = success.peek(
+                    v -> { throw exception; },
+                    e -> fail("Failure consumer should not be executed")
+            );
+
+            // Assert
+            assertTrue(result.isFailure(), "Result should be a Failure");
+            Exception resultException = ((Failure<String>) result).getException();
+            assertSame(exception, resultException, "Failure should contain the thrown exception");
+        }
+    }
+
+    @Nested
+    @DisplayName("When using peek with Failure")
+    class WhenUsingPeekWithFailure {
+
+        private final Exception exception = new RuntimeException("Test exception");
+        private final Try<String> failure = Try.failure(exception);
+
+        @Test
+        @DisplayName("Should execute only the failure consumer")
+        void shouldExecuteOnlyTheFailureConsumer() {
+            // Arrange
+            AtomicBoolean successConsumerExecuted = new AtomicBoolean(false);
+            AtomicBoolean failureConsumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            failure.peek(
+                    v -> successConsumerExecuted.set(true),
+                    e -> failureConsumerExecuted.set(true)
+            );
+
+            // Assert
+            assertFalse(successConsumerExecuted.get(), "Success consumer should not be executed");
+            assertTrue(failureConsumerExecuted.get(), "Failure consumer should be executed");
+        }
+
+        @Test
+        @DisplayName("Should return original Failure when consumer completes normally")
+        void shouldReturnOriginalFailureWhenConsumerCompletesNormally() {
+            // Arrange
+            AtomicBoolean failureConsumerExecuted = new AtomicBoolean(false);
+
+            // Act
+            Try<String> result = failure.peek(
+                    v -> fail("Success consumer should not be executed"),
+                    e -> failureConsumerExecuted.set(true)
+            );
+
+            // Assert
+            assertTrue(failureConsumerExecuted.get(), "Failure consumer should be executed");
+            assertSame(failure, result, "Should return the original Failure instance");
+        }
+
+        @Test
+        @DisplayName("Should return new Failure when failure consumer throws exception")
+        void shouldReturnNewFailureWhenFailureConsumerThrowsException() {
+            // Arrange
+            RuntimeException consumerException = new RuntimeException("Consumer exception");
+
+            // Act
+            Try<String> result = failure.peek(
+                    v -> fail("Success consumer should not be executed"),
+                    e -> { throw consumerException; }
+            );
+
+            // Assert
+            assertTrue(result.isFailure(), "Result should be a Failure");
+            assertSame(consumerException, ((Failure<String>) result).getException(), "Failure should contain the thrown exception");
+        }
+    }
+
+    @Nested
+    @DisplayName("When handling edge cases")
+    class WhenHandlingEdgeCases {
+
+        @Test
+        @DisplayName("Should throw NullPointerException when consumer is null in peekSuccess")
+        void shouldThrowNullPointerExceptionWhenConsumerIsNullInPeekSuccess() {
+            // Arrange
+            Try<String> success = Try.success("test");
+
+            // Act & Assert
+            assertThrows(NullPointerException.class, () -> success.peekSuccess(null),
+                    "Should throw NullPointerException when consumer is null");
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when consumer is null in peekFailure")
+        void shouldThrowNullPointerExceptionWhenConsumerIsNullInPeekFailure() {
+            // Arrange
+            Try<String> failure = Try.failure(new RuntimeException("Test exception"));
+
+            // Act & Assert
+            assertThrows(NullPointerException.class, () -> failure.peekFailure(null),
+                    "Should throw NullPointerException when consumer is null");
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when success consumer is null in peek")
+        void shouldThrowNullPointerExceptionWhenSuccessConsumerIsNullInPeek() {
+            // Arrange
+            Try<String> success = Try.success("test");
+
+            // Act & Assert
+            assertThrows(NullPointerException.class, () -> success.peek(null, e -> {}),
+                    "Should throw NullPointerException when success consumer is null");
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when failure consumer is null in peek")
+        void shouldThrowNullPointerExceptionWhenFailureConsumerIsNullInPeek() {
+            // Arrange
+            Try<String> success = Try.success("test");
+
+            // Act & Assert
+            assertThrows(NullPointerException.class, () -> success.peek(v -> {}, null),
+                    "Should throw NullPointerException when failure consumer is null");
+        }
+
+        @Test
+        @DisplayName("Should execute multiple peek calls in sequence")
+        void shouldExecuteMultiplePeekCallsInSequence() {
+            // Arrange
+            AtomicInteger counter = new AtomicInteger(0);
+            Try<String> success = Try.success("test");
+
+            // Act
+            Try<String> result = success
+                    .peekSuccess(v -> counter.incrementAndGet())
+                    .peekSuccess(v -> counter.incrementAndGet())
+                    .peekSuccess(v -> counter.incrementAndGet());
+
+            // Assert
+            assertEquals(3, counter.get(), "All three consumers should be executed");
+            assertSame(success, result, "Should return the original Success instance");
+        }
+
+        @Test
+        @DisplayName("Should integrate with map method")
+        void shouldIntegrateWithMapMethod() throws Exception {
+            // Arrange
+            AtomicBoolean beforeMapExecuted = new AtomicBoolean(false);
+            AtomicBoolean afterMapExecuted = new AtomicBoolean(false);
+            Try<String> success = Try.success("test");
+
+            // Act
+            Try<Integer> result = success
+                    .peekSuccess(v -> beforeMapExecuted.set(true))
+                    .map(String::length)
+                    .peekSuccess(v -> afterMapExecuted.set(true));
+
+            // Assert
+            assertTrue(beforeMapExecuted.get(), "Consumer before map should be executed");
+            assertTrue(afterMapExecuted.get(), "Consumer after map should be executed");
+            assertTrue(result.isSuccess(), "Result should be a Success");
+            assertEquals(4, result.get(), "Result should contain the mapped value");
+        }
+
+        @Test
+        @DisplayName("Should integrate with recover method")
+        void shouldIntegrateWithRecoverMethod() throws Exception {
+            // Arrange
+            AtomicBoolean beforeRecoverExecuted = new AtomicBoolean(false);
+            AtomicBoolean afterRecoverExecuted = new AtomicBoolean(false);
+            Try<String> failure = Try.failure(new RuntimeException("Test exception"));
+
+            // Act
+            Try<String> result = failure
+                    .peekFailure(e -> beforeRecoverExecuted.set(true))
+                    .recover(e -> "recovered")
+                    .peekSuccess(v -> afterRecoverExecuted.set(true));
+
+            // Assert
+            assertTrue(beforeRecoverExecuted.get(), "Consumer before recover should be executed");
+            assertTrue(afterRecoverExecuted.get(), "Consumer after recover should be executed");
+            assertTrue(result.isSuccess(), "Result should be a Success");
+            assertEquals("recovered", result.get(), "Result should contain the recovered value");
+        }
+
+        @Test
+        @DisplayName("Should integrate with andFinally method")
+        void shouldIntegrateWithAndFinallyMethod() {
+            // Arrange
+            AtomicBoolean peekExecuted = new AtomicBoolean(false);
+            AtomicBoolean finallyExecuted = new AtomicBoolean(false);
+            Try<String> success = Try.success("test");
+
+            // Act
+            Try<String> result = success
+                    .peekSuccess(v -> peekExecuted.set(true))
+                    .andFinally(() -> finallyExecuted.set(true));
+
+            // Assert
+            assertTrue(peekExecuted.get(), "Peek consumer should be executed");
+            assertTrue(finallyExecuted.get(), "Finally action should be executed");
+            assertSame(success, result, "Should return the original Success instance");
+        }
+    }
+}


### PR DESCRIPTION
## Description
This pull request adds new peek methods (`peekSuccess`, `peekFailure`, and `peek`) to the `Try` interface, enhancing the library's functional programming capabilities.

These methods allow for executing side effects on the content of a Try instance without altering the Try itself, which is useful for debugging, logging, or monitoring the flow of operations in a chain of transformations.

## Changes
- Added `peekSuccess`, `peekFailure`, and `peek` methods to the `Try` interface
- Implemented these methods in both `Success` and `Failure` classes
- Added tests for various scenarios
- Updated documentation with usage examples
- Updated the changelog